### PR TITLE
CI += linting and validation of charts

### DIFF
--- a/template/.gitignore
+++ b/template/.gitignore
@@ -6,3 +6,4 @@ venv*
 **/Chart.lock
 **/charts
 **/*copy
+.ci_work

--- a/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}.gitlab{% endif %}/ci_verify.sh
+++ b/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}.gitlab{% endif %}/ci_verify.sh
@@ -21,14 +21,15 @@ if ! docker version &>/dev/null; then docker=podman; else docker=docker; fi
 for service in ${ROOT}/services/*/  # */ to skip files
 do
 
-    ### Validate and lint each service chart ###
+    ### Lint each service chart and validate if schema given ###
     service_name=$(basename $service)
+    cp -r $service ${ROOT}/.ci_work/$service_name
     schema=$(cat ${service}/values.yaml | sed -rn 's/^# yaml-language-server: \$schema=(.*)/\1/p')
     if [ -n "${schema}" ]; then
-        cp -r $service ${ROOT}/.ci_work/$service_name
         echo "{\"\$ref\": \"$schema\"}" > ${ROOT}/.ci_work/$service_name/values.schema.json
-        helm lint ${ROOT}/.ci_work/$service_name --values ${ROOT}/services/values.yaml
     fi
+    helm dependency update ${ROOT}/.ci_work/$service_name
+    helm lint ${ROOT}/.ci_work/$service_name --values ${ROOT}/services/values.yaml
 
     ### Valiate each ioc config ###
     # Skip if subfolder has no config to validate


### PR DESCRIPTION
Example values.yaml input:
```
# yaml-language-server: $schema=https://github.com/epics-containers/ec-helm-charts/releases/download/4.1.0/ioc-instance.schema.json#/$defs/service
ioc-instance:
  image: True
  imag: ghcr.io/epics-containers/ioc-template-example-runtime:3.5.1
```
Example CI output:
```
 [esq51579@pc0146 b01-1-services]$ bash .gitlab/ci_verify.sh 
Saving 1 charts
Downloading ioc-instance from repo oci://ghcr.io/epics-containers
Pulled: ghcr.io/epics-containers/ioc-instance:4.0.0
Digest: sha256:d01bf34e2edc6f042fd49a250f7cc02482559f1d8ae3ac26c9dc913294582c02
Deleting outdated charts
==> Linting /home/esq51579/WIP/migration/b01-1-services/.ci_work/b01-1-ea-test-01
[INFO] Chart.yaml: icon is recommended
[ERROR] values.yaml: - ioc-instance: Additional property imag is not allowed
- ioc-instance.image: Invalid type. Expected: string, given: boolean

[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
ec-service:
- ioc-instance: Additional property imag is not allowed
- ioc-instance.image: Invalid type. Expected: string, given: boolean
```

Note:
- Requires helm to be installed
- We can also do this for the deployment-template
- Linting is done for all charts in services/*/ but validation is only done for charts with `# yaml-language-server: $schema=`