### PR TITLE
allow ioc.schema.yaml in the ibek-defs folder for ci_verify

### DIFF
--- a/template/ci_verify.sh
+++ b/template/ci_verify.sh
@@ -75,7 +75,8 @@ do
             -v ${service}/config:/config:z \
             ${image} \
             -c "
-            ibek runtime generate /config/ioc.yaml /epics/ibek-defs/*  &&
+            ibek runtime generate /config/ioc.yaml \
+              /epics/ibek-defs/*.ibek.support.yaml  &&
             cat /epics/runtime/st.cmd
             "
 


### PR DESCRIPTION
This is because the ansible build puts the schema in ibekdefs and previously ci_verify naively treated all files in there as *ibek.support.yaml.