### PR TITLE
ci: Remove daq-nexus from services with ci skipped

### DIFF
--- a/template/.ci_skip_checks
+++ b/template/.ci_skip_checks
@@ -1,1 +1,0 @@
-daq-nexus


### PR DESCRIPTION
Remove daq-nexus from services skipped by ci generally- this is only required for beamlines that are hosted on github (where the NeXus service Helm chart is not available to be fetched by ci), and services are now being prefixed with the beamline name rather than the group which manages them (with iocs being prefixed `blxxi`, and daq services `ixx`).

This file can then be managed manually for p46-p49, without the confusion and Diamond specificity in other repositories