### PR TITLE
Enable rabbitmq metrics collection

### DIFF
--- a/template/services/{% if "rabbitmq" in athena_services %}{{instrument}}-rabbitmq{% endif %}/values.yaml.jinja
+++ b/template/services/{% if "rabbitmq" in athena_services %}{{instrument}}-rabbitmq{% endif %}/values.yaml.jinja
@@ -22,3 +22,5 @@ rabbitmq:
       - name: stomp
         port: 61613
         targetPort: stomp
+  metrics:
+    enabled: true


### PR DESCRIPTION
**BLOCKED**: by https://diamondlightsource.slack.com/archives/CSWSUAXN0/p1749640080751619

RabbitMQ Helm chart's default configuration is already formatted to be compatible with Diamond's Prometheus infrastructure:

```yaml
metrics:
  enabled: false
  podAnnotations:
    prometheus.io/scrape: "true"
    prometheus.io/port: "{{ .Values.service.ports.metrics }}"
```

Enabling metrics and these annotations will allow the RMQ pod to be scraped by Prometheus and data propagated for beamline and facility wide information.