### PR TITLE
Configure rabbitmq to add default credentials to stomp Connect frame

### DIFF
--- a/template/services/{% if "rabbitmq" in athena_services %}{{instrument}}-rabbitmq{% endif %}/values.yaml.jinja
+++ b/template/services/{% if "rabbitmq" in athena_services %}{{instrument}}-rabbitmq{% endif %}/values.yaml.jinja
@@ -1,4 +1,7 @@
 rabbitmq:
+  extraConfiguration: |-
+    stomp.default_user = guest
+    stomp.default_pass = guest
   auth:
     username: admin
     existingPasswordSecret: rabbitmq-secrets


### PR DESCRIPTION
This allows any stomp clients e.g. blueapi (TBD: make another commit to remove the credentials from blueapi config?) but also any analysis consumers e.g. the gda_zocalo_connector