### PR TITLE
fix: add default credentials for Stomp connections

### DIFF
--- a/template/services/{% if "rabbitmq" in athena_services %}{{instrument}}-rabbitmq{% endif %}/values.yaml.jinja
+++ b/template/services/{% if "rabbitmq" in athena_services %}{{instrument}}-rabbitmq{% endif %}/values.yaml.jinja
@@ -1,4 +1,7 @@
 rabbitmq:
+  extraConfiguration: |-
+    stomp.default_user = guest
+    stomp.default_pass = guest
   auth:
     username: admin
     existingPasswordSecret: rabbitmq-secrets


### PR DESCRIPTION
Stomp connections therefore do not require authentication to be passed in the Connect frame, which makes behaviour more similar to how ActiveMQ behaves on beamline