### PR TITLE
fix: Skip nexus check in GitHub CI

### DIFF
--- a/template/.ci_skip_checks.jinja
+++ b/template/.ci_skip_checks.jinja
@@ -1,0 +1,1 @@
+{% if "nexus" in athena_services and git_platform == "github.com"%}{{instrument}}-nexus{% endif %}


### PR DESCRIPTION
As nexus service is hosted internal on https://sonatypenexus.diamond.ac.uk/repository/daq-helm/ It is not accessible in GitHub so skipping it`s check in GitHub CI 