### PR TITLE
update gitlab runner python to 3.13

### DIFF
--- a/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}.gitlab-ci.yml{% endif %}
+++ b/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}.gitlab-ci.yml{% endif %}
@@ -6,7 +6,7 @@ verify:
   tags:
     - epics-containers
     - argus
-  image: python:3.11
+  image: python:3.13
   variables:
     DOCKER_PROVIDER: kodman
   script:

--- a/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}requirements.txt{% endif %}
+++ b/template/{% if  git_platform == 'gitlab.diamond.ac.uk' %}requirements.txt{% endif %}
@@ -1,0 +1,2 @@
+urllib3<2.4.0
+Kodman


### PR DESCRIPTION
This also pins urllib because the latest version does not like DLS cluster certificates.

This is a preventative PR, because some people were upgrading their python version in the gitlab runner and then seeing the urllib related error.