### PR TITLE
Add BEAMLINE, INSTRUMENT environmental variables

### DIFF
--- a/template/services/{% if "blueapi" in athena_services %}{{instrument}}-blueapi{% endif %}/values.yaml.jinja
+++ b/template/services/{% if "blueapi" in athena_services %}{{instrument}}-blueapi{% endif %}/values.yaml.jinja
@@ -8,6 +8,12 @@ blueapi:
           - path: /
             pathType: Prefix
   
+  extraEnvVars:
+    - name: BEAMLINE
+      value: {{ instrument }}
+    - name: INSTRUMENT
+      value: {{ instrument }}
+
   worker:
     env:
       metadata:


### PR DESCRIPTION
BlueAPI uses the `$INSTRUMENT` environmental variable in logging metadata. The `$BEAMLINE` env var is for backwards compatibility.