### PR TITLE
Add python version to ibek generate-schema

### DIFF
--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
           bash -c "
             support=$(find ibek-runtime-support/ -name '*.ibek.support.yaml')
             if [[ -n ${support} ]]; then
-              uvx ibek ioc generate-schema ${support} \
+              uvx --python 3.13 ibek ioc generate-schema ${support} \
                 --output ibek-runtime-support/runtime.schema.json
             fi"
         files: ^ibek-runtime-support/


### PR DESCRIPTION
Python 3.13 is required to generate schemas; this PR specifies this version in the pre-commit config.