### PR TITLE
update helm charts to 5.3.0

### DIFF
--- a/template/.helm-shared/Chart.yaml
+++ b/template/.helm-shared/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 dependencies:
   - name: ioc-instance
-    version: 5.2.4
+    version: 5.3.0
     repository: "oci://ghcr.io/epics-containers/charts"
     import-values:
       - child: ioc-instance

--- a/template/.helm-shared/values.schema.json
+++ b/template/.helm-shared/values.schema.json
@@ -13,15 +13,15 @@
             "description": "Shared values for the root `services/values.yaml`. Use Anchor at the root to share the whole object between ioc-instance/dev-c7/fastcs as needed. Or use anchors on properties to create multiple sharable objects. Use a merge key (<<: *shared) to merge in the shared values where needed."
         },
         "ioc-instance": {
-            "$ref": "https://github.com/epics-containers/ec-helm-charts/releases/download/5.1.0/ioc-instance.schema.json#/properties/ioc-instance",
+            "$ref": "https://github.com/epics-containers/ec-helm-charts/releases/download/5.3.0/ioc-instance.schema.json#/properties/ioc-instance",
             "type": "object",
-            "additionalProperties": false,
+            "unevaluatedProperties": false,
             "description": "Shared values for ioc-instance charts. These represent ibek IOCs"
         },
         "dev-c7": {
             "$ref": "https://github.com/DiamondLightSource/dev-c7/releases/download/2025.11.1/dev-c7.values.schema.json",
             "type": "object",
-            "additionalProperties": false,
+            "unevaluatedProperties": false,
             "description": "Shared values for dev-c7 charts. These represent DLS legacy IOCs running out of the shared file system"
         }
     },

--- a/template/services/{{ domain }}-epics-opis/Chart.yaml
+++ b/template/services/{{ domain }}-epics-opis/Chart.yaml
@@ -8,5 +8,5 @@ type: application
 
 dependencies:
   - name: epics-opis
-    version: 5.2.4
+    version: 5.3.0
     repository: "oci://ghcr.io/epics-containers/charts"

--- a/template/services/{{ domain }}-epics-pvcs/Chart.yaml
+++ b/template/services/{{ domain }}-epics-pvcs/Chart.yaml
@@ -8,5 +8,5 @@ type: application
 
 dependencies:
   - name: epics-pvcs
-    version: 5.2.4
+    version: 5.3.0
     repository: "oci://ghcr.io/epics-containers/charts"


### PR DESCRIPTION
don't merge this until I have resolved how 'labels' in deployment repo should work with @OCopping 

This brings in
- labels work 
- fixes schema issues
- the commit hash for ixx-synoptic.

See https://github.com/epics-containers/ec-helm-charts/pull/96 for the helm chart changes
See https://github.com/losisin/helm-values-schema-json/issues/317 for a bug report on schema generation that is partially fixed in this PR here: https://github.com/epics-containers/services-template-helm/pull/95/changes/32487d79e5e8abb8e8e6c4ac2efc23170f69b4b5#diff-02cfaafdb1f50fbbcd5b698b26edc00895a90bc90b447b3c39033167ec011ae2R18