### PR TITLE
Fix blueapi readme typo

### DIFF
--- a/template/services/{% if "blueapi" in athena_services %}{{instrument}}-blueapi{% endif %}/README.md.jinja
+++ b/template/services/{% if "blueapi" in athena_services %}{{instrument}}-blueapi{% endif %}/README.md.jinja
@@ -45,7 +45,7 @@ To request an Ingress for `{{ instrument }}-blueapi.diamond.ac.uk` in the `{{ cl
 
   To seal both secrets, ensure you are connected to the correct cluster via:
   ```
-  module load k8s-{{ cluster_name }}
+  module load {{ cluster_name }}
   ```
   Then, having obtaining both secrets, seal them with the following commands:
   ```


### PR DESCRIPTION
Avoids generating `k8s-k8s-ixx`