### PR TITLE
Update README.md.jinja to remove extra k8s

### DIFF
--- a/template/services/{% if "blueapi" in athena_services %}{{instrument}}-blueapi{% endif %}/README.md.jinja
+++ b/template/services/{% if "blueapi" in athena_services %}{{instrument}}-blueapi{% endif %}/README.md.jinja
@@ -45,7 +45,7 @@ To request an Ingress for `{{ instrument }}-blueapi.diamond.ac.uk` in the `{{ cl
 
   To seal both secrets, ensure you are connected to the correct cluster via:
   ```
-  module load k8s-{{ cluster_name }}
+  module load {{ cluster_name }}
   ```
   Then, having obtaining both secrets, seal them with the following commands:
   ```


### PR DESCRIPTION
The `cluster_name` is already e.g. `k8s-b21` so at the moment this suggests `module load k8s-k8s-b21`, see https://gitlab.diamond.ac.uk/controls/containers/beamline/b21-services/-/tree/main/services/b21-blueapi