### PR TITLE
Fix how CI runs on a branch

### DIFF
--- a/template/ci_verify.sh
+++ b/template/ci_verify.sh
@@ -39,10 +39,10 @@ uvx pre-commit run --all-files --show-diff-on-failure
 # Determine diff base (also used later to pick the changed services)
 if [[ -n "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-}" ]]; then
     # GitLab MR
-    DIFF_BASE="origin/${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}"
+    DIFF_BASE=$(git merge-base HEAD "origin/${CI_MERGE_REQUEST_TARGET_BRANCH_NAME}")
 elif [[ -n "${GITHUB_BASE_REF:-}" ]]; then
     # GitHub PR
-    DIFF_BASE="origin/${GITHUB_BASE_REF}"
+    DIFF_BASE=$(git merge-base HEAD "origin/${GITHUB_BASE_REF}")
 elif git rev-parse HEAD~1 >/dev/null 2>&1; then
     # normal push
     DIFF_BASE="HEAD~1"


### PR DESCRIPTION
Change to use `git merge-base` to make sure CI runs relative to the branch point, not the tip of main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI change detection by comparing updates against the correct common ancestor with the target branch.
  * Increased reliability of verification results across GitLab and GitHub workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->