### PR TITLE
add support for groups of IOCs via the ioc-group chart

### DIFF
--- a/template/.helm-shared/GroupChart.yaml
+++ b/template/.helm-shared/GroupChart.yaml
@@ -1,0 +1,18 @@
+# A Helm Chart for a group of IOC instances that differ only by environment
+apiVersion: v2
+name: ec-group-service
+version: 1.0.0
+
+type: application
+
+# ioc-group renders the ioc-instance library once per entry in .Values.iocs,
+# so it pulls ioc-instance in for us - do not depend on ioc-instance here too.
+# The packaged ioc-group vendors the ioc-instance it was built against, which
+# is the same source as ioc-instance 5.7.0-beta.2.
+dependencies:
+  - name: ioc-group
+    version: 5.7.0-beta.2
+    repository: "oci://ghcr.io/epics-containers/charts"
+    import-values:
+      - child: ioc-instance
+        parent: ioc-instance

--- a/template/.helm-shared/group/templates/ioc_group.yaml
+++ b/template/.helm-shared/group/templates/ioc_group.yaml
@@ -1,0 +1,1 @@
+{{ include "ioc-group" . }}

--- a/template/.helm-shared/values.schema.json
+++ b/template/.helm-shared/values.schema.json
@@ -27,6 +27,11 @@
         "epics-pvcs": {
             "type": "object",
             "description": "Shared values for epics-pvcs chart."
+        },
+        "iocs": {
+            "$ref": "https://github.com/epics-containers/ec-helm-charts/releases/download/5.7.0-beta.2/ioc-group.schema.json#/properties/iocs",
+            "type": "array",
+            "description": "Shared values for ioc-group charts. These represent a group of ibek IOCs that differ only by environment"
         }
     },
     "unevaluatedProperties": false

--- a/template/services/.group_ioc_template/Chart.yaml
+++ b/template/services/.group_ioc_template/Chart.yaml
@@ -1,0 +1,1 @@
+../../.helm-shared/GroupChart.yaml

--- a/template/services/.group_ioc_template/config/ioc.yaml
+++ b/template/services/.group_ioc_template/config/ioc.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=../ioc.schema.json
+
+# Runtime config shared by EVERY IOC in this group (config/ is mounted as the
+# K8s ConfigMap). It specialises itself per instance because IOC_NAME differs
+# per instance, and because ioc-group adds that instance's variables from
+# values.yaml to the container environment.
+# Add vendored support: ibek pattern add <library>:<pattern>@<tag> services/<instance>
+ioc_name: "{{ _global.get_env('IOC_NAME') }}"
+
+description: REPLACE_WITH_DESCRIPTION
+
+entities:
+  - type: epics.EpicsEnvSet
+    name: EPICS_TZ
+    value: GMT0BST
+
+  - type: epics.EpicsEnvSet
+    name: STREAM_PROTOCOL_PATH
+    value: /epics/runtime/protocol/
+
+  - type: devIocStats.iocAdminSoft
+    IOC: "{{ ioc_name | upper }}"
+
+  # Derive anything that differs between the IOCs from the environment, e.g.
+  # a PV prefix from the instance name and a setting from values.yaml:
+  #
+  #   - type: REPLACE.WithEntity
+  #     P: "{{ ioc_name | upper }}"
+  #     SOMETHING: "{{ _global.get_env('REPLACE_WITH_VARIABLE') }}"
+
+  # - todo: Add more entities to make a meaningful IOC

--- a/template/services/.group_ioc_template/templates
+++ b/template/services/.group_ioc_template/templates
@@ -1,0 +1,1 @@
+../../.helm-shared/group/templates

--- a/template/services/.group_ioc_template/values.yaml
+++ b/template/services/.group_ioc_template/values.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=../../.helm-shared/values.schema.json
+
+# A group of IOCs that differ only by environment - one config folder, one
+# image, one set of resources, rendered once per entry in iocs below.
+# For a single IOC use .ioc_template instead.
+
+# settings shared by every IOC in the group
+ioc-instance:
+  image: REPLACE_WITH_IMAGE_URI
+
+  # mount in the beamline data folder
+  # dataVolume:
+  #   pvc: false
+  #   hostPath: /dls/ixx/data
+
+# One entry per IOC. Every entry MUST have a NAME - it is appended to the
+# release name, so a folder called ixx-ea-thing deploys ixx-ea-thing-01 and
+# ixx-ea-thing-02 below, each with its own StatefulSet, ConfigMap and PVC.
+# The remaining keys become extra container environment variables for that
+# IOC alone; read them back in config/ioc.yaml with _global.get_env().
+#
+# NOTE: the variables reach the container in alphabetical order, so do not
+# rely on k8s $(VAR) references between them.
+iocs:
+  - NAME: "01"
+    REPLACE_WITH_VARIABLE: REPLACE_WITH_VALUE
+
+  - NAME: "02"
+    REPLACE_WITH_VARIABLE: REPLACE_WITH_ANOTHER_VALUE


### PR DESCRIPTION
Adds support for **groups of IOCs** to the template, using the new
[`ioc-group`](https://github.com/epics-containers/ec-helm-charts/tree/main/Charts/ioc-group)
chart. One service folder, one image, one config folder — many IOCs that differ only by
their environment.

```yaml
iocs:
  - NAME: "01"
    WIDTH: "1024"
  - NAME: "02"
    WIDTH: "640"
```

Each entry's `NAME` is appended to the release name, so a folder called `ixx-ea-thing`
deploys `ixx-ea-thing-01` and `ixx-ea-thing-02`, each with its own StatefulSet, Service,
ConfigMap and PVC. The remaining keys become extra container environment for that IOC
alone, and the shared `config/ioc.yaml` reads them back with `_global.get_env()`.

## Changes

| path | purpose |
| --- | --- |
| `.helm-shared/GroupChart.yaml` | chart for group services, alongside `Chart.yaml` and `LegacyChart.yaml` |
| `.helm-shared/group/templates/ioc_group.yaml` | `{{ include "ioc-group" . }}` |
| `.helm-shared/values.schema.json` | new `iocs` property, `$ref`ing the published `ioc-group.schema.json` |
| `services/.group_ioc_template/` | skeleton to copy, joining `.ioc_template` and friends |

The nesting under `group/` is deliberate: the `check-yaml` hook excludes `/templates/`, and
a flat `group-templates/` folder would not match that pattern and would fail on the helm
template syntax.

## Testing

Built a mock generated repo from the template and rendered it: pulls
`ioc-group:5.7.0-beta.2`, produces `ixx-ea-thing-01` and `-02` with distinct StatefulSets,
ConfigMaps and PVCs and the right per-instance environment. `helm lint` passes, and the
`iocs` `$ref` resolves and correctly rejects an entry missing `NAME`.

This is also running for real: see `bl47p-ea-simdet` in `p47-services`, three simulated
detectors deployed through ArgoCD from a single folder.

## Note on versions

`ioc-group` has only prerelease builds so far, so `GroupChart.yaml` pins **5.7.0-beta.2**
while the single-IOC `Chart.yaml` stays on stable 5.6.1. This wants bumping once
`ioc-group` merges to main and gets a stable release — Renovate will not do it
automatically (prereleases, plus the `ec charts` rule is disabled in generated repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for deploying groups of environment-specific IOCs through a reusable application template.
  - Added shared configuration for IOC naming, EPICS environment settings, administration statistics, and runtime metadata.
  - Added options for shared container images, optional data volumes, and per-IOC environment variables.
  - Added validation and default configuration to help ensure consistent IOC group deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->